### PR TITLE
New test case for jobs with one concurrent

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,3 +167,15 @@ class MultipleConcurrentRestrictionJob
     sleep 0.5
   end
 end
+
+class OneConcurrentRestrictionJob
+  extend RunCountHelper
+  extend Resque::Plugins::ConcurrentRestriction
+  concurrent 1
+
+  @queue = 'normal'
+
+  def self.perform(*args)
+    sleep 0.5
+  end
+end


### PR DESCRIPTION
I expected that only one concurrent job will be run if set concurrent = 1, but 2 jobs were run instead!
I added new test case for this issue.
