### PR TITLE
Replace resque constantize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ rvm:
 #  - rbx-18mode
 #  - rbx-19mode
 script: bundle exec rspec spec
+services:
+  - redis-server

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ resque-concurrent-restriction
 
 Resque Concurrent Restriction is a plugin for the [Resque][0] queueing system (http://github.com/defunkt/resque). It allows one to specify how many of the given job can run concurrently.
 
-Resque Concurrent Restriction requires Resque 1.10 and redis 2.2
+Resque Concurrent Restriction requires Resque 1.25 and redis 2.2
 
 [![Build Status](https://secure.travis-ci.org/wr0ngway/resque-concurrent-restriction.png)](http://travis-ci.org/wr0ngway/resque-concurrent-restriction)
 

--- a/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
+++ b/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
@@ -18,6 +18,10 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
+      # Warning: The helpers module will be gone in Resque 2.x
+      # Resque::Helpers removed from Resque in 1.25, see:
+      # https://github.com/resque/resque/issues/1150#issuecomment-27942972
+      include Resque::Helpers
 
       # Allows configuring via class accessors
       class << self
@@ -130,7 +134,7 @@ module Resque
       end
 
       def tracking_class(tracking_key)
-        Resque.constantize(tracking_key.split(".")[2])
+        constantize(tracking_key.split(".")[2])
       end
 
       # The key to the redis set where we keep a list of runnable tracking_keys

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("resque", '~> 1.10')
+  s.add_dependency("resque", '~> 1.25')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -22,11 +22,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency("resque", '~> 1.10')
 
-  s.add_development_dependency('json')
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')
 
   # Needed for testing newer resque on ruby 1.8.7
   s.add_development_dependency('json')
-
 end

--- a/spec/concurrent_restriction_job_spec.rb
+++ b/spec/concurrent_restriction_job_spec.rb
@@ -170,8 +170,8 @@ describe Resque::Plugins::ConcurrentRestriction do
       t3.join
 
       t1.join
-      did_run1.should be_false
-      did_run2.should be_true
+      did_run1.should be_falsey
+      did_run2.should be_truthy
     end
 
   end
@@ -218,7 +218,7 @@ describe Resque::Plugins::ConcurrentRestriction do
     end
 
     it "should increment running count" do
-      ConcurrentRestrictionJob.stub!(:concurrent_limit).and_return(2)
+      ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(2)
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 0
       ConcurrentRestrictionJob.increment_running_count(ConcurrentRestrictionJob.tracking_key).should == false
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 1
@@ -229,7 +229,7 @@ describe Resque::Plugins::ConcurrentRestriction do
     end
 
     it "should decrement running count" do
-      ConcurrentRestrictionJob.stub!(:concurrent_limit).and_return(2)
+      ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(2)
       ConcurrentRestrictionJob.set_running_count(ConcurrentRestrictionJob.tracking_key, 3)
       ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key).should == true
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 2
@@ -240,14 +240,14 @@ describe Resque::Plugins::ConcurrentRestriction do
     end
 
     it "should not decrement running count below 0" do
-      ConcurrentRestrictionJob.stub!(:concurrent_limit).and_return(1)
+      ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(1)
       ConcurrentRestrictionJob.set_running_count(ConcurrentRestrictionJob.tracking_key, 0)
       ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key).should == false
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 0
     end
 
     it "should be able to tell when restricted" do
-      ConcurrentRestrictionJob.stub!(:concurrent_limit).and_return(1)
+      ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(1)
       ConcurrentRestrictionJob.set_running_count(ConcurrentRestrictionJob.tracking_key, 0)
       ConcurrentRestrictionJob.restricted?(ConcurrentRestrictionJob.tracking_key).should == false
       ConcurrentRestrictionJob.set_running_count(ConcurrentRestrictionJob.tracking_key, 1)
@@ -348,7 +348,7 @@ describe Resque::Plugins::ConcurrentRestriction do
       ConcurrentRestrictionJob.push_to_restriction_queue(job1)
       ConcurrentRestrictionJob.push_to_restriction_queue(job2)
       ConcurrentRestrictionJob.push_to_restriction_queue(job3)
-      ConcurrentRestrictionJob.stub!(:concurrent_limit).and_return(5)
+      ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(5)
 
       ConcurrentRestrictionJob.pop_from_restriction_queue(ConcurrentRestrictionJob.tracking_key, "somequeue")
       ConcurrentRestrictionJob.runnables.sort.should == [ConcurrentRestrictionJob.tracking_key]

--- a/spec/concurrent_restriction_job_spec.rb
+++ b/spec/concurrent_restriction_job_spec.rb
@@ -271,9 +271,7 @@ describe Resque::Plugins::ConcurrentRestriction do
       ConcurrentRestrictionJob.restriction_queue(ConcurrentRestrictionJob.tracking_key, "somequeue").should == [job1, job2, job3]
       ConcurrentRestrictionJob.push_to_restriction_queue(job4, :front)
       ConcurrentRestrictionJob.restriction_queue(ConcurrentRestrictionJob.tracking_key, "somequeue").should == [job4, job1, job2, job3]
-      should raise_exception() do
-        ConcurrentRestrictionJob.push_to_restriction_queue(job1, :bad)
-      end
+      lambda { ConcurrentRestrictionJob.push_to_restriction_queue(job1, :bad) }.should raise_exception
     end
 
     it "should pop jobs from restriction queue" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,7 @@ module PerformJob
   def run_resque_queue(queue, opts={})
     worker = Resque::Worker.new(queue)
     worker.very_verbose = true if opts[:verbose]
+    worker.term_child = true
 
     # do a single job then shutdown
     def worker.done_working


### PR DESCRIPTION
Resque 1.25.0 broke semantic versioning by no longer including `Resque::Helpers` methods. This should fix #6.