### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/lib/resque/plugins/concurrent_restriction/version.rb
+++ b/lib/resque/plugins/concurrent_restriction/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
-      VERSION = "0.5.9"
+      VERSION = "0.6.0"
     end
   end
 end


### PR DESCRIPTION
It looks like after the last PR was merged, the gem version wasn't bumped and a new version wasn't built.

Since it fixes a compatibility issue with Resque 1.25, and it feels like a new side of the coin is being turned, I chose to do a minor version bump.

There are a few other things I'd like to fix in coming PRs, but for now this shall do.