### PR TITLE
Remove Resque::Helpers deprecation warning

### DIFF
--- a/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
+++ b/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
@@ -15,13 +15,12 @@
 #      config.restricted_before_queued = true
 #    end
 
+require 'active_support'
+
 module Resque
   module Plugins
     module ConcurrentRestriction
-      # Warning: The helpers module will be gone in Resque 2.x
-      # Resque::Helpers removed from Resque in 1.25, see:
-      # https://github.com/resque/resque/issues/1150#issuecomment-27942972
-      include Resque::Helpers
+      include ::ActiveSupport::Inflector
 
       # Allows configuring via class accessors
       class << self

--- a/lib/resque/plugins/concurrent_restriction/version.rb
+++ b/lib/resque/plugins/concurrent_restriction/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
-      VERSION = "0.6.0"
+      VERSION = "0.6.1"
     end
   end
 end

--- a/lib/resque/plugins/concurrent_restriction/version.rb
+++ b/lib/resque/plugins/concurrent_restriction/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
-      VERSION = "0.5.9"
+      VERSION = "0.6.0"
     end
   end
 end

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -2,7 +2,6 @@
 $:.push File.expand_path("../lib", __FILE__)
 require 'resque/plugins/concurrent_restriction/version'
 
-
 Gem::Specification.new do |s|
   s.name        = "resque-concurrent-restriction"
   s.version     = Resque::Plugins::ConcurrentRestriction::VERSION
@@ -21,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("resque", '~> 1.25')
+  s.add_dependency("activesupport", '~> 3.2')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')


### PR DESCRIPTION
It's quite annoying that the deprecation warning shows every time the application stack is loaded, so I've swapped the dependency from `Resque::Helpers` (which is going away) to `ActiveSupport::Inflection`, which is where the more common `constantize` method is defined.

There are alternatives to this, but for the time being this seems like a sane move forward.

Expected criticisms would be that pessimistic versioning to 3.x.x is too low for activesupport, and I don't disagree... however I didn't take the time to look at the progression of `ActiveSupport` beyond 3.2.x because that's the limitation to the necessity of my current application of the gem. Another might be that ActiveSupport is too large to include for a mere single helper, and I don't necessarily disagree with that either, but the Resque core team hasn't left us with much choice in the matter since they've removed the helper themselves without supplying a replacement - besides, the majority of consumers of Resque tend to be using the Rails framework anyway.