### PR TITLE
ActiveJob support

### DIFF
--- a/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
+++ b/lib/resque/plugins/concurrent_restriction/concurrent_restriction_job.rb
@@ -383,7 +383,7 @@ module Resque
       # to release_restriction when job completes
       def stash_if_restricted(job)
         restricted = nil
-        tracking_key = tracking_key(*job.args)
+        tracking_key = tracking_key(*Helper.job_args(job))
         lock_key = lock_key(tracking_key)
 
         did_run = run_atomically(lock_key) do
@@ -434,7 +434,7 @@ module Resque
 
       # Decrements the running_count - to be called at end of job
       def release_restriction(job)
-        tracking_key = tracking_key(*job.args)
+        tracking_key = tracking_key(*Helper.job_args(args))
         lock_key = lock_key(tracking_key)
 
         run_atomically(lock_key) do

--- a/lib/resque/plugins/concurrent_restriction/resque_worker_extension.rb
+++ b/lib/resque/plugins/concurrent_restriction/resque_worker_extension.rb
@@ -26,22 +26,34 @@ module Resque
         # This needs to be a instance method
         def done_working_with_restriction
           begin
-            job_class = @job_in_progress.payload_class
-            job_class.release_restriction(@job_in_progress) if job_class.is_a?(ConcurrentRestriction)
+            job_class = Helper.payload_class @job_in_progress
+            job_class.release_restriction(@job_in_progress) if Helper.restrict_concurrency? job_class
           ensure
             return done_working_without_restriction
           end
         end
-        
+      end
+
+      module Helper
+        # ActiveJobs are an ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper
+        # Check the payload for the class we'd like them to be when they're run.
+        def self.payload_class(job)
+          return job.payload_class if job.payload_class.is_a? ConcurrentRestriction
+          class_name = job.args[0]['job_class']
+          Object.const_get class_name
+        end
+
+        def self.restrict_concurrency?(job_class)
+          job_class.is_a? ConcurrentRestriction
+        end
       end
 
       module Job
-
         def self.extended(receiver)
-           class << receiver
-             alias reserve_without_restriction reserve
-             alias reserve reserve_with_restriction
-           end
+          class << receiver
+            alias reserve_without_restriction reserve
+            alias reserve reserve_with_restriction
+          end
         end
 
         # Wrap reserve so we can move a job to restriction queue if it is restricted
@@ -74,16 +86,13 @@ module Resque
             # Short-curcuit if a job was not found
             return if resque_job.nil?
 
-            # If there is a job on regular queues, then only run it if its not restricted
-            job_class = resque_job.payload_class
-            job_args = resque_job.args
-
             # Return to work on job if not a restricted job
-            return resque_job unless job_class.is_a?(ConcurrentRestriction)
+            job_class = Helper.payload_class(resque_job)
+            return resque_job unless Helper.restrict_concurrency? job_class
 
             # Keep trying if job is restricted. If job is runnable, we keep the lock until
             # done_working
-            return resque_job unless job_class.stash_if_restricted(resque_job)
+            return resque_job unless job_class.stash_if_restricted resque_job
           end
 
           # Safety net, here in case we hit the upper bound and there are still queued items

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("resque", '~> 1.25')
-  s.add_dependency("activesupport", '~> 3.2')
+  s.add_dependency("activesupport", '~> 4')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')


### PR DESCRIPTION
Hello,

Thanks for your work on this plugin, it's really handy!

We're using `ActiveJob` which rather frustratingly wraps the job classes so the `is_a?` checks don't work and the jobs think there's no concurrency restriction.

I've had a quick hack at adding support for `ActiveJob`. Are you interested in this approach? If so I'll continue this PR and cover the change properly with tests.

Any feedback welcome.

Cheers,
Craig
