### PR TITLE
Addition of concurrent "running set" alternative to "count" 

### DIFF
--- a/lib/resque-concurrent-restriction.rb
+++ b/lib/resque-concurrent-restriction.rb
@@ -8,7 +8,7 @@ Resque::Job.send(:extend, Resque::Plugins::ConcurrentRestriction::Job)
 
 unsupported_version = false
 begin
-  server_ver = Resque.redis.info["redis_version"].split('.').collect{|x| x.to_i}
+  server_ver = Resque.data_store.redis.info["redis_version"].split('.').collect{|x| x.to_i}
   unsupported_version = (server_ver <=> [2, 2, 0]) < 0
 rescue
 end

--- a/lib/resque/plugins/concurrent_restriction/version.rb
+++ b/lib/resque/plugins/concurrent_restriction/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
-      VERSION = "0.6.3"
+      VERSION = "0.6.4"
     end
   end
 end

--- a/lib/resque/plugins/concurrent_restriction/version.rb
+++ b/lib/resque/plugins/concurrent_restriction/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
-      VERSION = "0.6.1"
+      VERSION = "0.6.2"
     end
   end
 end

--- a/lib/resque/plugins/concurrent_restriction/version.rb
+++ b/lib/resque/plugins/concurrent_restriction/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module ConcurrentRestriction
-      VERSION = "0.6.2"
+      VERSION = "0.6.3"
     end
   end
 end

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("resque", '~> 1.25')
-  s.add_dependency("activesupport", '~> 3.2')
+  s.add_dependency("activesupport", '~> 4.2.5.1')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("resque", '~> 1.25')
-  s.add_dependency("activesupport", '~> 4.2.5.1')
+  s.add_dependency("activesupport", '~> 3.2')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')

--- a/resque-concurrent-restriction.gemspec
+++ b/resque-concurrent-restriction.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("resque", '~> 1.25')
-  s.add_dependency("activesupport", '~> 3.2')
+  s.add_dependency("activesupport", '>= 3.2')
 
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('awesome_print')

--- a/spec/concurrent_restriction_job_spec.rb
+++ b/spec/concurrent_restriction_job_spec.rb
@@ -220,29 +220,29 @@ describe Resque::Plugins::ConcurrentRestriction do
     it "should increment running count" do
       ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(2)
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 0
-      ConcurrentRestrictionJob.increment_running_count(ConcurrentRestrictionJob.tracking_key).should == false
+      ConcurrentRestrictionJob.increment_running_count(ConcurrentRestrictionJob.tracking_key, 0).should == false
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 1
-      ConcurrentRestrictionJob.increment_running_count(ConcurrentRestrictionJob.tracking_key).should == true
+      ConcurrentRestrictionJob.increment_running_count(ConcurrentRestrictionJob.tracking_key, 0).should == true
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 2
-      ConcurrentRestrictionJob.increment_running_count(ConcurrentRestrictionJob.tracking_key).should == true
+      ConcurrentRestrictionJob.increment_running_count(ConcurrentRestrictionJob.tracking_key, 0).should == true
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 3
     end
 
     it "should decrement running count" do
       ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(2)
       ConcurrentRestrictionJob.set_running_count(ConcurrentRestrictionJob.tracking_key, 3)
-      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key).should == true
+      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key, 0).should == true
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 2
-      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key).should == false
+      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key, 0).should == false
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 1
-      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key).should == false
+      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key, 0).should == false
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 0
     end
 
     it "should not decrement running count below 0" do
       ConcurrentRestrictionJob.stub(:concurrent_limit).and_return(1)
       ConcurrentRestrictionJob.set_running_count(ConcurrentRestrictionJob.tracking_key, 0)
-      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key).should == false
+      ConcurrentRestrictionJob.decrement_running_count(ConcurrentRestrictionJob.tracking_key, 0).should == false
       ConcurrentRestrictionJob.running_count(ConcurrentRestrictionJob.tracking_key).should == 0
     end
 


### PR DESCRIPTION
The purpose of this code change is to handle concurrency job count not being decremented after a resque worker dirty exit. This causes restricted concurrent jobs to remain enqueued indefinitely since the code thinks there are jobs being worked on while there actually are not.

Rather than using a running count, a set of jobs is kept, with jobs being added and removed upon start and finish. Each time a job is attempted to be enqueued, a check is done to cross reference the jobs currently being worked on by each worker and the jobs in the running set. Any jobs that are in the running set but not actually being worked on are removed, allowing the restricted check to be done based on the correct number.

The gem still will default to the count configuration so this will not affect current users. To change to the new set configuration, the class accessor "tracking_type" must be set to "set" in the configuration step. Note, the set configuration of the gem will only work when the job args are unique for each job.