### PR TITLE
[#15] remove deprecation warnings

### DIFF
--- a/lib/resque-concurrent-restriction.rb
+++ b/lib/resque-concurrent-restriction.rb
@@ -8,7 +8,7 @@ Resque::Job.send(:extend, Resque::Plugins::ConcurrentRestriction::Job)
 
 unsupported_version = false
 begin
-  server_ver = Resque.redis.info["redis_version"].split('.').collect{|x| x.to_i}
+  server_ver = Resque.data_store.redis.info["redis_version"].split('.').collect{|x| x.to_i}
   unsupported_version = (server_ver <=> [2, 2, 0]) < 0
 rescue
 end


### PR DESCRIPTION
Addresses issue #15, accessing the redis connection directly when running the `info` method.